### PR TITLE
Convert subset to use derive

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ impl From<MyOtherType> for MyExpansiveType {
 ## Subtype
 
 Sometimes you'll want to describe that a given enum is a subtype of another enum without actually having access to the original enum.
-This can be accomplished with the `subtype_of` attr macro.
+This can be accomplished with the `Subtype` derive macro and the `subtype_of` attribute.
 
 ```
+#[derive(Subtype)]
 #[subtype_of(SomeSuperType)]
 enum MySubType {
   Variant1,

--- a/typesets-macro/src/lib.rs
+++ b/typesets-macro/src/lib.rs
@@ -12,8 +12,8 @@ pub fn supertype_derive(item: TokenStream) -> TokenStream {
     gen_supertype(item.into()).into()
 }
 
-#[proc_macro_attribute]
+#[proc_macro_derive(Subtype, attributes(subtype_of))]
 #[proc_macro_error]
-pub fn subtype_of(input: TokenStream, item: TokenStream) -> TokenStream {
-    gen_subtype(input.into(), item.into()).into()
+pub fn subtype_of(input: TokenStream) -> TokenStream {
+    gen_subtype(input.into()).into()
 }


### PR DESCRIPTION
For consistency sake and the ability for add other options in the future I've converted the subset behavior to be a derive instead of just being and attr macro. 